### PR TITLE
Fix: Add ModemStatus handling to StatusKind enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 /target
-**/*.rs.bk
-rustup-init.exe
 
 config.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
+**/*.rs.bk
+rustup-init.exe
 
 config.json

--- a/src/belabox/messages.rs
+++ b/src/belabox/messages.rs
@@ -95,6 +95,8 @@ pub enum StatusKind {
     Wifi(WifiChange),
     #[serde(rename = "available_updates")]
     AvailableUpdates(AvailableUpdatesStatus),
+    #[serde(rename = "modems")]
+    ModemStatus(ModemStatus),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -233,6 +235,11 @@ pub struct Server {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct Account {
     pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct ModemStatus {
+    pub modems: HashMap<String, serde_json::Value>,
 }
 
 #[cfg(test)]

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -157,6 +157,7 @@ async fn handle_belabox_messages(
                     }
                     StatusKind::Wifi(_) => {}
                     StatusKind::AvailableUpdates(_) => {}
+                    StatusKind::ModemStatus(_) => {}
                 };
 
                 if lock.restart {


### PR DESCRIPTION
This pull request fixes a deserialization error that occurs when BELABOX sends only modem status information.

Changes:
- Added new ModemStatus variant to StatusKind enum
- Created ModemStatus structure
- Updated match statement in bot.rs to handle ModemStatus

The error occurred with:
failed to deserialize e=Error("data did not match any variant of untagged enum StatusKind", line: 0, column: 0) obj=("status", Object {"modems": Object {}})

This change enables proper handling of status messages that contain only modem information.